### PR TITLE
Merge back v2024.2.27-alpha.2410 to GH-16_enable-deployment-on-github

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "npmClient": "npm",
   "packages": ["systems/api", "systems/web", "systems/infrastructure"],
-  "version": "2024.2.27-alpha.1759"
+  "version": "2024.2.27-alpha.2410"
 }

--- a/systems/api/package-lock.json
+++ b/systems/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "api",
-  "version": "2024.2.27-alpha.1759",
+  "version": "2024.2.27-alpha.2410",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "api",
-      "version": "2024.2.27-alpha.1759",
+      "version": "2024.2.27-alpha.2410",
       "license": "UNLICENSED",
       "dependencies": {
         "@apollo/server": "4.10.0",

--- a/systems/api/package.json
+++ b/systems/api/package.json
@@ -91,5 +91,5 @@
     "test": "API_ENV=test NODE_ENV=test jest --maxWorkers=50%",
     "test:ci": "API_ENV=test NODE_ENV=test Ci=true jest --coverage --ci --runInBand --bail"
   },
-  "version": "2024.2.27-alpha.1759"
+  "version": "2024.2.27-alpha.2410"
 }

--- a/systems/infrastructure/Pulumi.development.yaml
+++ b/systems/infrastructure/Pulumi.development.yaml
@@ -1,5 +1,5 @@
 encryptionsalt: v1:eu6KLsBnOdY=:v1:dqrXLbxMTJslVOrR:TpPZ8xvl1ssp7Zb3Wj/fmiyJz2NBlA==
 config:
-  gcp:credentials: /home/runner/work/made-in-uk/made-in-uk/gha-creds-cb04fbec5e459a63.json
+  gcp:credentials: /home/runner/work/made-in-uk/made-in-uk/gha-creds-8b6e5ba6e073031a.json
   gcp:project: made-in-uk
   gcp:region: europe-west2

--- a/systems/infrastructure/package-lock.json
+++ b/systems/infrastructure/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "infrastructure",
-  "version": "2024.2.27-alpha.1759",
+  "version": "2024.2.27-alpha.2410",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "infrastructure",
-      "version": "2024.2.27-alpha.1759",
+      "version": "2024.2.27-alpha.2410",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "7.7.0",

--- a/systems/infrastructure/package.json
+++ b/systems/infrastructure/package.json
@@ -37,5 +37,5 @@
     "build": "npx babel --out-dir ./bin --extensions .ts --ignore ./src/gcp/**/node_modules --copy-files --no-copy-ignored ./src"
   },
   "type": "module",
-  "version": "2024.2.27-alpha.1759"
+  "version": "2024.2.27-alpha.2410"
 }

--- a/systems/web/package-lock.json
+++ b/systems/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "2024.2.27-alpha.1759",
+  "version": "2024.2.27-alpha.2410",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "2024.2.27-alpha.1759",
+      "version": "2024.2.27-alpha.2410",
       "license": "UNLICENSED",
       "dependencies": {
         "@remix-run/css-bundle": "2.7.2",

--- a/systems/web/package.json
+++ b/systems/web/package.json
@@ -45,5 +45,5 @@
   },
   "sideEffects": false,
   "type": "module",
-  "version": "2024.2.27-alpha.1759"
+  "version": "2024.2.27-alpha.2410"
 }


### PR DESCRIPTION
Bump version to v2024.2.27-alpha.2410